### PR TITLE
srt文件解析与去重

### DIFF
--- a/src/srtCtl/__init__.py
+++ b/src/srtCtl/__init__.py
@@ -1,0 +1,3 @@
+from src.srtCtl.core.YTSrtController import YTSrtController
+
+__all__ = ["YTSrtController"]

--- a/src/srtCtl/core/YTSrtController.py
+++ b/src/srtCtl/core/YTSrtController.py
@@ -1,0 +1,3 @@
+class YTSrtController:
+    def __init__(self):
+        pass

--- a/src/srtCtl/core/modules/SubtitleItem.py
+++ b/src/srtCtl/core/modules/SubtitleItem.py
@@ -1,0 +1,12 @@
+from typing import List
+
+class SubtitleItem:
+    def __init__(self, index: int, start: str, end: str, texts: List[str]):
+        self.index = index
+        self.start = start
+        self.end = end
+        self.texts = texts
+        
+    # 宠溺定义如何组织成srt的形式，如用于print
+    def __str__(self):
+        return f"{self.index}\n{self.start} --> {self.end}\n" + "\n".join(self.texts)

--- a/src/srtCtl/core/modules/__init__.py
+++ b/src/srtCtl/core/modules/__init__.py
@@ -1,0 +1,1 @@
+from .SubtitleItem import SubtitleItem

--- a/src/srtCtl/core/parser/__init__.py
+++ b/src/srtCtl/core/parser/__init__.py
@@ -1,0 +1,1 @@
+from .srt_parser import SrtParser

--- a/src/srtCtl/core/parser/srt_parser.py
+++ b/src/srtCtl/core/parser/srt_parser.py
@@ -1,0 +1,34 @@
+import pysrt
+from src.srtCtl.core.modules.SubtitleItem import SubtitleItem
+
+class SrtParser:
+    def parse(self, path):
+        try:
+            subs = pysrt.open(path, encoding='utf-8')
+        except Exception as e:
+            raise ValueError(f"Failed to parse SRT file: {e}")
+        
+        items = [
+            SubtitleItem(
+                index=sub.index,
+                start=str(sub.start),
+                end=str(sub.end),
+                texts=sub.text.splitlines()
+            ) for sub in subs
+        ] # 原始数据
+        
+        length = len(items) # 字幕条数
+        
+        texts = [item.texts for item in items] # 去重前的字幕，二维列表，texts[i]是第i条字幕的文本，是2行
+        
+        texts_deduplicated = [] # 去重后的字幕，不包括空行，一维列表
+        for lines in texts:
+            for line in lines:
+                text = line.strip()
+                if not text:
+                    continue # 空行不记录
+                latest_text = texts_deduplicated[-1] if texts_deduplicated else None
+                if latest_text != text:
+                    texts_deduplicated.append(text)
+                
+        return items, length, texts, texts_deduplicated

--- a/src/srtCtl/core/writer/__init__.py
+++ b/src/srtCtl/core/writer/__init__.py
@@ -1,0 +1,1 @@
+from .srt_writer import SrtWriter

--- a/src/srtCtl/core/writer/srt_writer.py
+++ b/src/srtCtl/core/writer/srt_writer.py
@@ -1,0 +1,9 @@
+from src.srtCtl.core.modules.SubtitleItem import SubtitleItem
+
+class SrtWriter:
+    def write(self, items, out_path):
+        with open(out_path, 'w', encoding='utf-8') as f:
+            for item in items:
+                f.write(f"{item.index}\n")
+                f.write(f"{item.start} --> {item.end}\n")
+                f.write("\n".join(item.texts) + "\n\n")

--- a/tests/parserTest.py
+++ b/tests/parserTest.py
@@ -1,0 +1,39 @@
+import os, sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.srtCtl.core.parser.srt_parser import SrtParser
+
+def test_parse_first_srt_file():
+    # 在工作目录下的 srt-files 目录中选取第一个 .srt 文件
+    base = os.getcwd()
+    srt_dir = os.path.join(base, "srt-files")
+    srt_files = [f for f in os.listdir(srt_dir) if f.lower().endswith(".srt")]
+    assert srt_files, "srt-files 文件夹中没有 .srt 文件可供测试"
+    srt_path = os.path.join(srt_dir, srt_files[0])
+
+    parser = SrtParser()
+    items, length, texts, dedup = parser.parse(srt_path)
+    
+    print(f"去重去空后的字幕列表: {dedup}")
+
+    # 基本类型检查
+    assert isinstance(items, list)
+    assert isinstance(length, int) and length == len(items)
+    assert isinstance(texts, list)
+    assert isinstance(dedup, list)
+
+    # 每个 item 应该有 index、start、end、texts 四个属性
+    for itm in items:
+        assert hasattr(itm, "index")
+        assert hasattr(itm, "start")
+        assert hasattr(itm, "end")
+        assert hasattr(itm, "texts")
+        assert isinstance(itm.texts, list)
+
+    # dedup 中不应包含空字符串，且数量不超过总行数
+    assert all(isinstance(t, str) and t.strip() for t in dedup)
+    assert len(dedup) <= sum(len(lines) for lines in texts)
+    
+if __name__ == "__main__":
+    test_parse_first_srt_file()


### PR DESCRIPTION
Close #8 
srt文件解析与去重
在core文件夹里写了parser和writer，建了一个共用模块modules存放公用类比如SubtitleItem类，可能会被许多文件共用。已经自测好了。
youtube字幕因为会带有上一条，比如第一个字幕块是A，空，下一个是A,B，下一个是B,C，下一个是C,空，然后C,D这样，就是会向上滚动。所以我们加了去重，parse函数返回只有4个：**原式字幕信息列表、字幕item数量、去重前的text列表，每个项对应原始字幕的text、去重后的text列表**，其中可能有用的是去重后的text列表，它保存的是A,B,C,D的字符串，并忽略空串，这里的去重不是指整体的去重，而是上下字幕块的去重。